### PR TITLE
Fix season handling in recipe service

### DIFF
--- a/src/lib/models/season.ts
+++ b/src/lib/models/season.ts
@@ -1,13 +1,13 @@
 export enum Season {
-  Spring = 'spring',
-  Summer = 'summer',
-  Autumn = 'autumn',
-  Winter = 'winter',
+  Spring = 'Spring',
+  Summer = 'Summer',
+  Fall = 'Fall',
+  Winter = 'Winter',
 }
 
 export const SeasonDisplay = {
   [Season.Spring]: 'Frühling',
   [Season.Summer]: 'Sommer',
-  [Season.Autumn]: 'Herbst',
+  [Season.Fall]: 'Herbst',
   [Season.Winter]: 'Winter',
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -61,7 +61,7 @@
   const seasons: { label: string; value: Season }[] = [
     { label: "Frühling", value: Season.Spring },
     { label: "Sommer", value: Season.Summer },
-    { label: "Herbst", value: Season.Autumn },
+    { label: "Herbst", value: Season.Fall },
     { label: "Winter", value: Season.Winter },
   ];
 


### PR DESCRIPTION
## Summary
- align `Season` enum with recipe dataset
- normalize recipe data while loading
- use Svelte `get` helper instead of subscriptions
- update page to use new `Season` enum values

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6846d9f4f28483228b021210622b4922