### PR TITLE
Map season strings to enum values

### DIFF
--- a/src/lib/services/recipeService.ts
+++ b/src/lib/services/recipeService.ts
@@ -3,14 +3,16 @@ import type { Recipe } from "$lib/models/recipe";
 import { Season } from "$lib/models/season";
 
 function normalizeSeason(value: string): Season {
-  switch (value) {
-    case 'Spring':
+  const season = value.trim().toLowerCase();
+  if (season.includes('autumn') || season.includes('fall')) {
+    return Season.Fall;
+  }
+  switch (season) {
+    case 'spring':
       return Season.Spring;
-    case 'Summer':
+    case 'summer':
       return Season.Summer;
-    case 'Fall':
-      return Season.Fall;
-    case 'Winter':
+    case 'winter':
       return Season.Winter;
     default:
       return Season.Summer;


### PR DESCRIPTION
## Summary
- normalize season strings when loading recipes
- keep filterBySeasonAndIngredient working with enum values

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6846e9931db08322b40df8c319fd6637