### PR TITLE
Switch to vegetarian recipes with no images

### DIFF
--- a/static/recipes.json
+++ b/static/recipes.json
@@ -1,71 +1,69 @@
 [
   {
     "id": 1,
-    "title": "Spaghetti Carbonara",
-    "description": "A classic Italian pasta dish made with eggs, cheese, pancetta, and pepper.",
+    "title": "Veggie Lasagna",
+    "description": "Layers of pasta with spinach, ricotta, and tomato sauce.",
     "season": "Winter",
-    "image": "https://example.com/images/spaghetti-carbonara.jpg",
     "ingredients": [
-      { "name": "spaghetti", "amount": "200g" },
-      { "name": "eggs", "amount": "2 large" },
-      { "name": "pancetta", "amount": "100g" },
-      { "name": "Parmesan cheese", "amount": "50g, grated" },
-      { "name": "black pepper", "amount": "to taste" },
-      { "name": "salt", "amount": "to taste" }
-    ]
-  },
-  {
-    "id": 2,
-    "title": "Tomato Soup",
-    "description": "A comforting soup made with fresh tomatoes, herbs, and a hint of cream.",
-    "season": "Fall",
-    "image": "https://example.com/images/tomato-soup.jpg",
-    "ingredients": [
-      { "name": "tomatoes", "amount": "1kg, chopped" },
-      { "name": "onion", "amount": "1 large, chopped" },
+      { "name": "lasagna noodles", "amount": "250g" },
+      { "name": "ricotta cheese", "amount": "200g" },
+      { "name": "spinach", "amount": "200g" },
+      { "name": "tomato sauce", "amount": "500ml" },
+      { "name": "mozzarella", "amount": "200g, shredded" },
       { "name": "garlic", "amount": "2 cloves, minced" },
-      { "name": "vegetable broth", "amount": "750ml" },
-      { "name": "heavy cream", "amount": "100ml" },
       { "name": "olive oil", "amount": "1 tbsp" },
       { "name": "salt", "amount": "to taste" },
       { "name": "black pepper", "amount": "to taste" }
     ]
   },
   {
-    "id": 3,
-    "title": "Grilled Chicken Salad",
-    "description": "A healthy salad with grilled chicken, greens, and a light vinaigrette.",
+    "id": 2,
+    "title": "Caprese Salad",
+    "description": "Tomatoes, mozzarella, and basil drizzled with olive oil.",
     "season": "Summer",
-    "image": "https://example.com/images/grilled-chicken-salad.jpg",
     "ingredients": [
-      { "name": "chicken breast", "amount": "2 breasts" },
-      { "name": "mixed salad greens", "amount": "200g" },
-      { "name": "cherry tomatoes", "amount": "150g, halved" },
-      { "name": "cucumber", "amount": "1, sliced" },
-      { "name": "olive oil", "amount": "1 tbsp" },
+      { "name": "tomatoes", "amount": "3 large, sliced" },
+      { "name": "mozzarella", "amount": "200g" },
+      { "name": "basil leaves", "amount": "handful" },
+      { "name": "olive oil", "amount": "2 tbsp" },
       { "name": "balsamic vinegar", "amount": "1 tbsp" },
       { "name": "salt", "amount": "to taste" },
       { "name": "black pepper", "amount": "to taste" }
     ]
   },
   {
-    "id": 4,
-    "title": "Beef Stew",
-    "description": "A hearty stew with tender beef, carrots, potatoes, and onions.",
-    "season": "Winter",
-    "image": "https://example.com/images/beef-stew.jpg",
+    "id": 3,
+    "title": "Grilled Vegetable Skewers",
+    "description": "Colorful veggies grilled on skewers with a light marinade.",
+    "season": "Summer",
     "ingredients": [
-      { "name": "beef stew meat", "amount": "500g, cubed" },
-      { "name": "carrots", "amount": "3, chopped" },
-      { "name": "potatoes", "amount": "4, cubed" },
-      { "name": "onion", "amount": "1 large, chopped" },
-      { "name": "garlic", "amount": "3 cloves, minced" },
-      { "name": "beef broth", "amount": "1 liter" },
+      { "name": "zucchini", "amount": "1, sliced" },
+      { "name": "bell peppers", "amount": "2, chopped" },
+      { "name": "mushrooms", "amount": "200g" },
+      { "name": "cherry tomatoes", "amount": "150g" },
+      { "name": "olive oil", "amount": "2 tbsp" },
+      { "name": "soy sauce", "amount": "1 tbsp" },
+      { "name": "garlic", "amount": "2 cloves, minced" },
+      { "name": "salt", "amount": "to taste" },
+      { "name": "black pepper", "amount": "to taste" }
+    ]
+  },
+  {
+    "id": 4,
+    "title": "Lentil Soup",
+    "description": "Hearty soup with lentils and vegetables.",
+    "season": "Winter",
+    "ingredients": [
+      { "name": "lentils", "amount": "200g" },
+      { "name": "carrots", "amount": "2, chopped" },
+      { "name": "celery", "amount": "2 stalks, chopped" },
+      { "name": "onion", "amount": "1, chopped" },
+      { "name": "vegetable broth", "amount": "1 liter" },
       { "name": "tomato paste", "amount": "2 tbsp" },
       { "name": "olive oil", "amount": "1 tbsp" },
+      { "name": "cumin", "amount": "1 tsp" },
       { "name": "salt", "amount": "to taste" },
-      { "name": "black pepper", "amount": "to taste" },
-      { "name": "bay leaves", "amount": "2" }
+      { "name": "black pepper", "amount": "to taste" }
     ]
   },
   {
@@ -73,7 +71,6 @@
     "title": "Vegetable Stir-fry",
     "description": "A quick and healthy stir-fry with mixed vegetables and soy sauce.",
     "season": "Spring",
-    "image": "https://example.com/images/vegetable-stir-fry.jpg",
     "ingredients": [
       { "name": "broccoli", "amount": "200g, florets" },
       { "name": "carrots", "amount": "2, julienned" },
@@ -92,7 +89,6 @@
     "title": "Pumpkin Soup",
     "description": "A smooth and creamy soup made with roasted pumpkin and spices.",
     "season": "Fall",
-    "image": "https://example.com/images/pumpkin-soup.jpg",
     "ingredients": [
       { "name": "pumpkin", "amount": "500g, peeled and cubed" },
       { "name": "onion", "amount": "1 large, chopped" },
@@ -107,17 +103,16 @@
   },
   {
     "id": 7,
-    "title": "Chicken Tacos",
-    "description": "Soft tortillas filled with seasoned chicken, salsa, and guacamole.",
+    "title": "Chickpea Tacos",
+    "description": "Soft tortillas filled with seasoned chickpeas and toppings.",
     "season": "Summer",
-    "image": "https://example.com/images/chicken-tacos.jpg",
     "ingredients": [
-      { "name": "chicken breast", "amount": "2 breasts, diced" },
+      { "name": "chickpeas", "amount": "400g, cooked" },
       { "name": "taco seasoning", "amount": "2 tbsp" },
       { "name": "soft tortillas", "amount": "8" },
       { "name": "salsa", "amount": "1/2 cup" },
-      { "name": "guacamole", "amount": "1/2 cup" },
-      { "name": "cheese", "amount": "1/2 cup, shredded" },
+      { "name": "avocado", "amount": "1, sliced" },
+      { "name": "lettuce", "amount": "1/2 head, shredded" },
       { "name": "cilantro", "amount": "1/4 cup, chopped" }
     ]
   },
@@ -126,7 +121,6 @@
     "title": "Eggplant Parmesan",
     "description": "Fried eggplant slices layered with marinara sauce and melted cheese.",
     "season": "Fall",
-    "image": "https://example.com/images/eggplant-parmesan.jpg",
     "ingredients": [
       { "name": "eggplant", "amount": "2 medium, sliced" },
       { "name": "breadcrumbs", "amount": "1 cup" },
@@ -144,7 +138,6 @@
     "title": "Caesar Salad",
     "description": "A classic Caesar salad with romaine lettuce, croutons, and creamy dressing.",
     "season": "Summer",
-    "image": "https://example.com/images/caesar-salad.jpg",
     "ingredients": [
       { "name": "romaine lettuce", "amount": "2 heads, chopped" },
       { "name": "croutons", "amount": "1 cup" },
@@ -156,17 +149,21 @@
   },
   {
     "id": 10,
-    "title": "Beef Tacos",
-    "description": "Soft tortillas filled with seasoned beef, cheese, and lettuce.",
+    "title": "Stuffed Bell Peppers",
+    "description": "Bell peppers filled with rice, beans, and cheese.",
     "season": "Spring",
-    "image": "https://example.com/images/beef-tacos.jpg",
     "ingredients": [
-      { "name": "ground beef", "amount": "500g" },
-      { "name": "taco seasoning", "amount": "2 tbsp" },
-      { "name": "soft tortillas", "amount": "8" },
+      { "name": "bell peppers", "amount": "4, halved" },
+      { "name": "cooked rice", "amount": "1 cup" },
+      { "name": "black beans", "amount": "1 cup" },
+      { "name": "corn", "amount": "1/2 cup" },
+      { "name": "tomato sauce", "amount": "1 cup" },
       { "name": "cheese", "amount": "1/2 cup, shredded" },
-      { "name": "lettuce", "amount": "1/2 head, shredded" },
-      { "name": "salsa", "amount": "1/4 cup" }
+      { "name": "onion", "amount": "1, chopped" },
+      { "name": "garlic", "amount": "2 cloves, minced" },
+      { "name": "olive oil", "amount": "1 tbsp" },
+      { "name": "salt", "amount": "to taste" },
+      { "name": "black pepper", "amount": "to taste" }
     ]
   },
   {
@@ -174,7 +171,6 @@
     "title": "Mushroom Risotto",
     "description": "Creamy risotto with sautéed mushrooms and Parmesan cheese.",
     "season": "Fall",
-    "image": "https://example.com/images/mushroom-risotto.jpg",
     "ingredients": [
       { "name": "Arborio rice", "amount": "200g" },
       { "name": "mushrooms", "amount": "200g, sliced" },


### PR DESCRIPTION
## Summary
- remove local images and references
- keep vegetarian recipes in `recipes.json` but without `image` field

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846eae0d6dc8322a2806583418ed8c1