### PR TITLE
Add recipe details modal

### DIFF
--- a/src/lib/models/recipe.ts
+++ b/src/lib/models/recipe.ts
@@ -10,4 +10,8 @@ export interface Recipe {
   image?: string;
   totalCo2?: number;
   totalPrice?: number;
+  duration?: string;
+  difficulty?: string;
+  calories?: number;
+  instructions?: string;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
   let selectedSeason: Season = Season.Summer;
   let selectedIngredients: string[] = [];
   let recipeService: RecipeService = new RecipeService();
+  let selectedRecipe: Recipe | null = null;
 
   onMount( async () => {
     // Initial laden nach default-Saison
@@ -69,6 +70,14 @@
     updateRecipesAndIngredients(season, []);
     loadRecipes(season, []);
   };
+
+  const openModal = (recipe: Recipe) => {
+    selectedRecipe = recipe;
+  };
+
+  const closeModal = () => {
+    selectedRecipe = null;
+  };
 </script>
 
 <!-- Header -->
@@ -118,7 +127,7 @@
   <div class="row">
     {#each recipes as recipe}
       <div class="col-md-4 mb-4 d-flex justify-content-center">
-        <div class="card h-100 shadow-sm">
+        <div class="card h-100 shadow-sm" role="button" style="cursor:pointer" on:click={() => openModal(recipe)}>
           <img
             src={recipe.image == null
               ? "/images/default.jpeg"
@@ -136,6 +145,48 @@
     {/each}
   </div>
 </div>
+
+{#if selectedRecipe}
+  <div class="modal fade show" tabindex="-1" style="display:block; background-color: rgba(0,0,0,0.5);" on:click|self={closeModal}>
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{selectedRecipe.title}</h5>
+          <button type="button" class="btn-close" aria-label="Close" on:click={closeModal}></button>
+        </div>
+        <div class="modal-body">
+          <div class="text-center mb-3">
+            <img
+              src={selectedRecipe.image == null ? '/images/default.jpeg' : getImage(selectedRecipe.image)}
+              class="img-fluid rounded"
+              alt="Bild vom Rezept"
+            />
+            <div class="d-flex justify-content-center gap-2 mt-2">
+              {#if selectedRecipe.duration}<span class="badge bg-info">{selectedRecipe.duration}</span>{/if}
+              {#if selectedRecipe.difficulty}<span class="badge bg-warning">{selectedRecipe.difficulty}</span>{/if}
+              <span class="badge bg-secondary">{selectedRecipe.season}</span>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-8">
+              <p>{selectedRecipe.description}</p>
+            </div>
+            <div class="col-md-4">
+              <ul class="list-group">
+                <li class="list-group-item d-flex justify-content-between"><span>Calories</span><span></span></li>
+                <li class="list-group-item d-flex justify-content-between"><span>Price</span><span></span></li>
+                <li class="list-group-item d-flex justify-content-between"><span>CO₂</span><span></span></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" on:click={closeModal}>Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <!-- Footer -->
 <Footer />


### PR DESCRIPTION
## Summary
- extend `Recipe` model with fields used by detail modal
- implement a modal in `+page.svelte` that opens on card click
- show recipe title, image, and tags in the modal
- placeholders for calories, price and CO₂

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6846f457cfbc8322ba94420b60b68382