### PR TITLE
Add CO₂ calculation via OpenFoodFacts

### DIFF
--- a/src/lib/services/co2Service.ts
+++ b/src/lib/services/co2Service.ts
@@ -1,0 +1,54 @@
+export class Co2Service {
+  private async fetchCo2Per100g(name: string): Promise<number> {
+    const query = encodeURIComponent(name);
+    const url = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${query}&json=true&page_size=1&fields=carbon-footprint-from-known-ingredients_100g`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        console.error('Failed to fetch CO2 data', res.status);
+        return 0;
+      }
+      const data = await res.json();
+      const product = data.products?.[0];
+      const value = product?.['carbon-footprint-from-known-ingredients_100g'];
+      return typeof value === 'number' ? value : 0;
+    } catch (err) {
+      console.error('Error fetching CO2 data', err);
+      return 0;
+    }
+  }
+
+  private convertToGrams(amount: number, unit: string): number {
+    switch (unit) {
+      case 'g':
+        return amount;
+      case 'ml':
+        return amount; // rough approximation
+      case 'l':
+        return amount * 1000;
+      case 'EL':
+        return amount * 15;
+      case 'TL':
+        return amount * 5;
+      case 'Tasse':
+        return amount * 240;
+      case 'Stk':
+      case 'Zehe':
+      case 'Kopf':
+      case 'Stange':
+        return amount * 100; // generic estimate
+      default:
+        return amount;
+    }
+  }
+
+  public async calculateRecipeCo2(recipe: any): Promise<number> {
+    let total = 0;
+    for (const ingredient of recipe.ingredients) {
+      const per100g = await this.fetchCo2Per100g(ingredient.name);
+      const amount = this.convertToGrams(ingredient.amount, ingredient.unit);
+      total += (per100g * amount) / 100;
+    }
+    return total;
+  }
+}

--- a/src/lib/services/recipeService.ts
+++ b/src/lib/services/recipeService.ts
@@ -2,6 +2,7 @@ import { writable, get } from "svelte/store";
 import type { Recipe } from "$lib/models/recipe";
 import { Season } from "$lib/models/season";
 import { Unit } from "$lib/models/unit";
+import { Co2Service } from "$lib/services/co2Service";
 
 function normalizeSeason(value: string): Season {
   const season = value.trim().toLowerCase();
@@ -66,6 +67,15 @@ export class RecipeService {
         };
       });
       console.log("Recipes loaded:", data); // Make sure recipes are loaded
+      const co2 = new Co2Service();
+      for (const recipe of data) {
+        try {
+          recipe.totalCo2 = await co2.calculateRecipeCo2(recipe);
+        } catch (err) {
+          console.error('CO2 calculation failed', err);
+          recipe.totalCo2 = 0;
+        }
+      }
       this.recipes.set(data); // Set recipes to the store
     } catch (error) {
       console.error("Error loading recipes:", error);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -179,7 +179,7 @@
               <ul class="list-group">
                 <li class="list-group-item d-flex justify-content-between"><span>Kalorien</span><span></span></li>
                 <li class="list-group-item d-flex justify-content-between"><span>Preis</span><span></span></li>
-                <li class="list-group-item d-flex justify-content-between"><span>CO₂</span><span></span></li>
+                <li class="list-group-item d-flex justify-content-between"><span>CO₂</span><span>{selectedRecipe.totalCo2?.toFixed(2)} g</span></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- fetch CO₂ data from OpenFoodFacts
- compute total CO₂ per recipe when loading recipes
- display the CO₂ value in the recipe modal

## Testing
- `npm run check`
- `npm run build`
- `curl -L https://world.openfoodfacts.org/cgi/search.pl?search_terms=tomato&json=true&page_size=1` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847139dad508322a106187eb5a11eea